### PR TITLE
Fix missing imports in coins.move

### DIFF
--- a/sources/coins.move
+++ b/sources/coins.move
@@ -1,7 +1,8 @@
 module coins::coins;
 
-use std::option::some;
+use std::option;
 use sui::coin::{Self, TreasuryCap, create_currency};
+use sui::transfer;
 use sui::url::new_unsafe_from_bytes;
 
 const TOTAL_COINS: u64 = 1_000_000_000_000_000_000;


### PR DESCRIPTION
## Summary
- add transfer and option imports to coins module

## Testing
- `sui move test` *(fails: `sui: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684437eadb708326afe9cd8c9433568a